### PR TITLE
Revamped anomaly spawn conditions.

### DIFF
--- a/Endless Space Competitive Mod/Simulation/AnomalyDefinitions
+++ b/Endless Space Competitive Mod/Simulation/AnomalyDefinitions
@@ -1,0 +1,988 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/AnomalyDefinition.xsd">
+
+
+    <AnomalyDefinition Name="PlanetAnomalyAcademy" Quality="Positive" Indestructible="true">
+        <SimulationDescriptorReference Name="PlanetAnomalyAcademy"/>
+      <GeneratorInfo ExcludeFromRandomPlacement="true"/>
+    </AnomalyDefinition>
+    
+    <AnomalyDefinition Name="PlanetAnomalyAcademyRestored" Quality="Mixed" Indestructible="true">
+        <SimulationDescriptorReference Name="PlanetAnomalyAcademyRestored"/>
+        <GeneratorInfo ExcludeFromRandomPlacement="true"/>
+    </AnomalyDefinition>
+
+    <AnomalyDefinition Name="PlanetAnomalyAcademyDestroyed" Quality="Mixed" Indestructible="true">
+        <SimulationDescriptorReference Name="PlanetAnomalyAcademyDestroyed"/>
+        <GeneratorInfo ExcludeFromRandomPlacement="true"/>
+    </AnomalyDefinition>
+    
+    <!-- Auriga's Anomaly -->
+    <AnomalyDefinition Name="PlanetAnomalyEndlessWonder1" Quality="Positive"  Indestructible="true">
+        <SimulationDescriptorReference Name="PlanetAnomalyEndlessWonder1"/>
+        <GeneratorInfo ExcludeFromRandomPlacement="true"/>
+    </AnomalyDefinition>
+
+    <!-- Bilgeli's Anomaly -->
+    <AnomalyDefinition Name="PlanetAnomalyEndlessWonder2" Quality="Positive"  Indestructible="true">
+        <SimulationDescriptorReference Name="PlanetAnomalyEndlessWonder2"/>
+        <GeneratorInfo ExcludeFromRandomPlacement="true"/>
+    </AnomalyDefinition>
+
+    <!-- Garden of Eden -->
+    <AnomalyDefinition Name="PlanetAnomaly01" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly01"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyGround"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+      <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly01</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+      </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Dust Ruins -->
+    <AnomalyDefinition Name="PlanetAnomaly02" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly02"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyGround"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly02</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Friendly Locals -->
+    <AnomalyDefinition Name="PlanetAnomaly03" Quality="Positive">   
+        <SimulationDescriptorReference Name="PlanetAnomaly03"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly03</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Rich Soil -->
+    <AnomalyDefinition Name="PlanetAnomaly04" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly04"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly04</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly43</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Mineral Rich -->
+    <AnomalyDefinition Name="PlanetAnomaly05" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly05"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly05</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Hadopelagic Life  -->
+    <AnomalyDefinition Name="PlanetAnomaly06" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly06"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyGround"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly06</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Antonov Ring -->
+    <AnomalyDefinition Name="PlanetAnomaly07" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly07"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyRing"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomalyRing</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Huygens Rings  -->
+    <AnomalyDefinition Name="PlanetAnomaly08" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly08"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyRing"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomalyRing</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Hollow Planet -->
+    <AnomalyDefinition Name="PlanetAnomaly09" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly09"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly09</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Ice-10 -->
+    <AnomalyDefinition Name="PlanetAnomaly10" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly10"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyGround"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly10</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeGasWarm</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeHot</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTemperate</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly10Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly10Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+        <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Permanent Monsoon -->
+    <AnomalyDefinition Name="PlanetAnomaly11" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly11"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyCloud"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly11</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly11Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly11Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Metallic Waters -->
+    <AnomalyDefinition Name="PlanetAnomaly12" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly12"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyGround"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly12</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly12Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly12Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Aurora Waves -->
+    <AnomalyDefinition Name="PlanetAnomaly13" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly13"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly13</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Dense Atmosphere (make mixed, decreases happiness and industry) -->
+    <AnomalyDefinition Name="PlanetAnomaly14" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly14"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyCloud"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly14</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Psychoactive Air -->
+    <AnomalyDefinition Name="PlanetAnomaly15" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly15"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyCloud"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly15</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly15Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly15Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Geothermic Activity -->
+    <AnomalyDefinition Name="PlanetAnomaly16" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly16"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyGround"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly16</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeLava</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeCold</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTemperate</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly16Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly16Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+    
+    <!-- Seismic Activity -->
+    <AnomalyDefinition Name="PlanetAnomaly17" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly17"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly17</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly17Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly17Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Long Season -->
+    <AnomalyDefinition Name="PlanetAnomaly18" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly18"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly18</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly41</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeCold</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeHot</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly18Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly18Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Meteor Strikes -->
+    <AnomalyDefinition Name="PlanetAnomaly19" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly19"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly19</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly19Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly19Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Polar Tempests -->
+    <AnomalyDefinition Name="PlanetAnomaly20" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly20"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyGround"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyNegative"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly20</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeHot</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTemperate</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly20Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly20Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Strong Magnetic Field -->
+    <AnomalyDefinition Name="PlanetAnomaly21" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly21"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyNegative"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly21</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly21Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly21Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Kessler Syndrome -->
+    <AnomalyDefinition Name="PlanetAnomaly22" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly22"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyNegative"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly22</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly22Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly22Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Acid Rain -->
+    <AnomalyDefinition Name="PlanetAnomaly23" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly23"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyCloud"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyNegative"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly23</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <AnomalyDefinition Name="PlanetAnomaly23Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly23Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Irradiated -->
+    <AnomalyDefinition Name="PlanetAnomaly24" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly24"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyNegative"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly24</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly24Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly24Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Single Moon -->
+    <AnomalyDefinition Name="PlanetAnomaly25" Quality="Moon">
+        <SimulationDescriptorReference Name="PlanetAnomaly25"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27Alt</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly25Reduced" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly25"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly25Alt" Quality="Moon">
+        <SimulationDescriptorReference Name="PlanetAnomaly25"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27Alt</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly25Explored" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly25Explored"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+
+    <!-- Two Moons -->
+    <AnomalyDefinition Name="PlanetAnomaly26" Quality="Moon">
+        <SimulationDescriptorReference Name="PlanetAnomaly26"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27Alt</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly26Reduced" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly26"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly26Alt" Quality="Moon">
+        <SimulationDescriptorReference Name="PlanetAnomaly26"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27Alt</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly26Explored" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly26Explored"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+        <EncounterEntityReference Name="PlanetAnomaly26"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Multiple Moons -->
+    <AnomalyDefinition Name="PlanetAnomaly27" Quality="Moon">
+        <SimulationDescriptorReference Name="PlanetAnomaly27"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27Alt</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly27Reduced" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly27"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly27Alt" Quality="Moon">
+        <SimulationDescriptorReference Name="PlanetAnomaly27"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>Curiosity_PlanetAnomaly27Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly25Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly26Alt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly27Alt</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly27Explored" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly27Explored"/>
+        <SimulationDescriptorReference Name="PlanetMoon"/>
+      <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Hostile Fauna -->
+    <AnomalyDefinition Name="PlanetAnomaly28" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly28"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly28</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeIce</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeLava</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeAsh</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly28Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly28Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+        <GeneratorInfo/>
+    </AnomalyDefinition>
+
+    <!-- Ancient Ruins -->
+    <AnomalyDefinition Name="PlanetAnomaly29" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly29"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly29</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    
+    <!-- Dust Lode -->
+    <AnomalyDefinition Name="PlanetAnomaly30" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly30"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly30</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Coral Reefs -->
+    <AnomalyDefinition Name="PlanetAnomaly31" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly31"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly31</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Cyber Flora  -->
+    <AnomalyDefinition Name="PlanetAnomaly32" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly32"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly32</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Strange Fossils -->
+    <AnomalyDefinition Name="PlanetAnomaly33" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly33"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly33</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeLava</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Microfactories -->
+    <AnomalyDefinition Name="PlanetAnomaly34" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly34"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly34</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeGasFrozen</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeGasBurning</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeGasCold</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeGasHot</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeLava</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Mutated Flora  -->
+    <AnomalyDefinition Name="PlanetAnomaly35" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly35"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly35</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Low Gravity  -->
+    <AnomalyDefinition Name="PlanetAnomaly36" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly36"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly36</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly44</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetSizeLarge</PlanetFilterNot>
+            <PlanetFilterNot>PlanetSizeHuge</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Deserted Cities  -->
+    <AnomalyDefinition Name="PlanetAnomaly37" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly37"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly37</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Molten Springs  -->
+    <AnomalyDefinition Name="PlanetAnomaly38" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly38"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyFX"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly38</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeCold</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTemperate</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Shattered Crust  -->
+    <AnomalyDefinition Name="PlanetAnomaly39" Quality="Mixed">
+        <SimulationDescriptorReference Name="PlanetAnomaly39"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly39</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly39Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly39Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Komatiite Volcano  -->
+    <AnomalyDefinition Name="PlanetAnomaly40" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly40"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly40</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeCold</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTemperate</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Propitious Seasons -->
+    <AnomalyDefinition Name="PlanetAnomaly41" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly41"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly41</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly18</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeCold</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeHot</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Humeris Insidentes -->
+    <AnomalyDefinition Name="PlanetAnomaly42" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly42"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly42</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeHot</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTemperate</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Poor Soil  -->
+    <AnomalyDefinition Name="PlanetAnomaly43" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly43"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyNegative"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly43</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetAnomaly04</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly43Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly43Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    
+    <!-- High Gravity  -->
+    <AnomalyDefinition Name="PlanetAnomaly44" Quality="Negative">
+        <SimulationDescriptorReference Name="PlanetAnomaly44"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyNegative"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly44</PlanetFilterNot>
+            <PlanetFilterNot>PlanetSizeTiny</PlanetFilterNot>
+            <PlanetFilterNot>PlanetSizeSmall</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+			<PlanetFilterNot>PlanetAnomaly36</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+    <AnomalyDefinition Name="PlanetAnomaly44Reduced" Quality="Reduced">
+        <SimulationDescriptorReference Name="PlanetAnomaly44Reduced"/>
+        <SimulationDescriptorReference Name="PlanetAnomalyReduced"/>
+        <GeneratorInfo>
+          <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+          <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+          <PlanetFilterNot>PlanetAnomaly36</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Behemoth Song  -->
+    <AnomalyDefinition Name="PlanetAnomaly45" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly45"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly45</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Talking World  -->
+    <AnomalyDefinition Name="PlanetAnomaly46" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly46"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly46</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Fearful Symmetry  -->
+    <AnomalyDefinition Name="PlanetAnomaly47" Quality="Positive">
+        <SimulationDescriptorReference Name="PlanetAnomaly47"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetAnomaly47</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+
+    <!-- Natural Wonders -->
+    
+    <!-- Dust Nebula -->
+    <AnomalyDefinition Name="PlanetAnomalyNaturalWonder1" Quality="Positive"  >
+        <SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder1"/>
+		<SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Seventeen Thousand Islands Bridges  -->
+    <AnomalyDefinition Name="PlanetAnomalyNaturalWonder2" Quality="Positive"  >
+        <SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder2"/>
+		<SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- The Fallen Gardens -->
+    <AnomalyDefinition Name="PlanetAnomalyNaturalWonder3" Quality="Positive"  >
+        <SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder3"/>
+		<SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Platform of Ys -->
+    <AnomalyDefinition Name="PlanetAnomalyNaturalWonder4" Quality="Positive"  >
+        <SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder4"/>
+		<SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Tree of World  -->
+    <AnomalyDefinition Name="PlanetAnomalyNaturalWonder5" Quality="Positive"  >
+        <SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder5"/>
+		<SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
+            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeMonsoon</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+
+    <!-- Tunneled Slipgate -->
+    <AnomalyDefinition Name="PlanetAnomalyNaturalWonder6" Quality="Positive"  >
+        <SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder6"/>
+		<SimulationDescriptorReference Name="PlanetAnomalyNaturalWonder"/>
+        <GeneratorInfo>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+        </GeneratorInfo>
+    </AnomalyDefinition>
+</Datatable>


### PR DESCRIPTION
Adds my anomaly spawn changes which are:
-Gas giant anomalies now spawn again
-It makes it more flexible when it comes to gas giants so you can get a lot of anomalies there that you previously couldn't like ice10 (only on the cold ones), meteor shower, psycoactive atmosphere, etc
-It removes dumb spawning like coral reefs on barren or polar tempests on lava or low gravity on huge planets or mutated flora on lava or hostile fauna on lava, etc
-It removes the possibility of duplicates
-it makes it possible for multiple of the same type (air, land, life, etc) to spawn on the same planet (the game didn't allow for this but only sometimes which was weird)
-I noticed there was a strong bias towards positive anomalies for fertile and the opposite for sterile so i distributed some anomalies around as in: volcanic ones spawn only on hot, some dust ones don't spawn on fertile (since the lore says that dust doesn't get along with life), i wanted to give cold planets something but i only had humeris incidents so they don't get much.